### PR TITLE
Added check for undefined module

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,8 @@ function resolveTree (db, module, opts, cb) {
     pkg.parent.tree[pkg.name] = pkg
   }
 
+  if (! module) return cb(null, {})
+
   resolvePackage(db, module.name, module.version, function (err, pkg) {
     if(err) return cb(err)
     var root = pkg


### PR DESCRIPTION
In the very rare instance that a module has both 0 dependencies and 0 devDependencies npmd-resolve appears to fail.  I'm not sure if this is the correct way to fix the issue, but it does work and doesn't cause any problems further down the tree (whereas returning `undefined` for the package info does).
