### PR TITLE
Detect the use of github references that dont have a git:// or http:// prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function resolvePackage (db, module, vrange, opts, cb) {
   if(!cb) cb = opts, opts = {}
   if(!cb) cb = vrange, vrange = '*'
 
-  if(/^(git|http)/.test(vrange)) {
+  if(/^(git|http|\w+\/)/.test(vrange)) {
     console.error('GET', vrange)
     return urlResolve(vrange, opts, function (err, pkg) {
       if(err)


### PR DESCRIPTION
As this can now be handled by `npmd-git-resolve` these urls should be passed through for git resolution rather than npm.
