### PR TITLE
GitHub URL resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/github.js
+++ b/github.js
@@ -1,0 +1,121 @@
+var spawn = require('child_process').spawn
+var querystring = require('querystring')
+var url = require('url')
+var util = require('util')
+var semver = require('semver')
+var request = require('request')
+
+var TOKEN
+function fillCredential(opts, cb) {
+  if(TOKEN)
+    return process.nextTick(function() { cb(null, TOKEN) })
+
+  var gc = spawn('git', ['credential', 'fill'])
+
+  var out = ''
+  gc.stdout.setEncoding('utf8')
+  gc.stdout.on('data', function(s) { out += s })
+
+  var err = ''
+  gc.stderr.setEncoding('utf8')
+  gc.stderr.on('data', function(s) { out += s })
+
+  gc.on('close', function(code) {
+    if(code !== 0) return cb(new Error(err.trim()))
+
+    var creds = querystring.parse(out.trim(), '\n')
+    if(creds.password !== 'x-oauth-basic')
+      return cb(new Error('Expected token from git credential'))
+
+    // TODO: Vary token cache by host
+    cb(null, TOKEN = creds.username)
+  })
+
+  gc.stdin.end(querystring.stringify(opts, '\n'))
+}
+
+function findReleaseInRange(owner, repo, vrange, cb) {
+  // TODO: GitHub Enterprise support
+  fillCredential({ host: 'github.com '}, function(err, token) {
+    if(err) return cb(err)
+
+    request({
+      url: 'https://api.github.com/repos/' + owner + '/' + repo + '/releases',
+      headers: {
+        'accept': 'application/vnd.github.v3+json',
+        'user-agent': 'dominictarr/npmd-resolve',
+        'authorization': 'token ' + token
+      }
+    }, function(err, res, data) {
+      if(err) return cb(err)
+
+      if(res.statusCode !== 200)
+        return cb(new Error('Unexpected ' + res.statusCode + ' response code'))
+
+      // TODO: Pagination
+      try { data = JSON.parse(data) } catch (err) { return cb(err) }
+      var tag = semver.maxSatisfying(
+        data.map(function(r) { return r.tag_name }).filter(semver.valid),
+        vrange)
+
+      if(!tag) return cb(new Error('Cannot find release for range ' + vrange))
+      cb(null, tag)
+    })
+  })
+}
+
+function getPackage(owner, repo, tag, cb) {
+  fillCredential({ host: 'github.com '}, function(err, token) {
+    if(err) return cb(err)
+
+    request({
+      url: 'https://api.github.com/repos/' + owner + '/' + repo + '/contents/package.json?ref=' + tag,
+      headers: {
+        'accept': 'application/vnd.github.v3+json',
+        'user-agent': 'dominictarr/npmd-resolve',
+        'authorization': 'token ' + token
+      }
+    }, function(err, res, data) {
+      if(err) return cb(err)
+
+      if(res.statusCode !== 200)
+        return cb(new Error('Unexpected ' + res.statusCode + ' response code'))
+
+      try { data = JSON.parse(data) } catch (err) { return cb(err) }
+
+      if(data.type !== 'file')
+        return cb(new Error('Expected package.json to be a file, was a' + data.type))
+
+      var pkg
+      try {
+        pkg = JSON.parse(new Buffer(data.content, data.encoding))
+      } catch (err) {
+        return cb(err)
+      }
+
+      // FIXME: If the repository is private, npmd-cache still won't be able to fetch it
+      pkg.from = util.format('git://github.com/%s/%s.git#%s', owner, repo, tag)
+      cb(null, pkg)
+    })
+  })
+}
+
+module.exports = function (module, vrange, opts, cb) {
+  var parsed = url.parse(vrange)
+  if(parsed.protocol !== 'github:')
+    return cb()
+
+
+  vrange = parsed.hash.slice(1)
+  if(!semver.validRange(vrange))
+    return cb()
+
+  var p = parsed.pathname.split('/')
+  var owner = p[1], repo = p[2]
+
+  findReleaseInRange(owner, repo, vrange, function(err, tag) {
+    if(err) return cb(err)
+
+    getPackage(owner, repo, tag, cb)
+  })
+}

--- a/resolve.js
+++ b/resolve.js
@@ -1,5 +1,6 @@
 var online = require('./online')
 var offline = require('./offline')
+var github = require('./github')
 var override = require('./override')
 
 var path = require('path')
@@ -34,6 +35,7 @@ module.exports = function (cache, config) {
         cb(err, pkg)
       })
     },
+    github,
     cache.resolve,
     function (m, v, opts, cb) {
       cb(new Error(


### PR DESCRIPTION
Follow-up to https://github.com/dominictarr/npmd-cache/pull/1.

Resolves URLs like `github://github.com/example/foo#^1.0.0` using the GitHub API. The semantic versioning range is compared against available releases in the repository. Can read from private repositories too.

The API token is obtained from the configured Git installation. To check whether your Git installation uses a GitHub API token run:

``` bash
echo 'host=github.com' | git credential fill
```

This should result in something like this:

```
host=github.com
username={token}
password=x-oauth-basic
```

Outstanding issues
- [ ] paginate over the releases, in case there's so many they don't fit in a single response
- [ ] GitHub Enterprise support
- [ ] `npmd-cache` still can't download from private repositories
