### PR TITLE
Fix urls

### DIFF
--- a/resolve-tree.js
+++ b/resolve-tree.js
@@ -16,8 +16,6 @@ function check(pkg, name, range) {
 
 function fixModule (module) {
   if('string' === typeof module) {
-  if(/\//.test(module)) // it's a url
-    return {version: module}
   var parts = module.split('@')
     return {name: parts.shift(), version: parts.shift() || '*'}
   }

--- a/test/test.js
+++ b/test/test.js
@@ -59,3 +59,13 @@ tape('resolves old range', function (t) {
     t.end()
   })
 })
+
+tape('resolves urls', function (t) {
+  var resolve = createResolve(function (m, v, opts, cb) {
+    t.equal(m, 'dominictarr/npmd-resolve#1.0.2')
+    t.equal(v, '*')
+    t.end()
+  })
+
+  resolve('dominictarr/npmd-resolve#1.0.2')
+})


### PR DESCRIPTION
See https://github.com/dominictarr/npmd-resolve/issues/11

Restores the behavior before 05d3cd054b20b72220edb57d81004399d725bad4, with code from master it would return `{version:"url"}`.
